### PR TITLE
bugfix: Window react event for 'Just Yuri' has an incorrect eventlabel

### DIFF
--- a/SCLwindowreacts.rpy
+++ b/SCLwindowreacts.rpy
@@ -410,7 +410,7 @@ init 5 python:
     addEvent(
         Event(
             persistent._mas_windowreacts_database,
-            eventlabel="mas_wrs_justnatsuki",
+            eventlabel="mas_wrs_justyuri",
             category=["Just Yuri"],
             rules={
                 "notif-group": "Window Reactions",


### PR DESCRIPTION
Hey,

I've realised that the creation of the remote branches for other repositories can be either done with foreign developers being in the Collaborators category or with the forks.

Anyway, this Pull Request fixes an incorrect eventlabel name in the SCLwindowreacts.rpy file. The category of the event suggests that the event refers to the "label mas_wrs_justyuri" (Line 426).