### PR TITLE
A "Retry?" Button causes a crash.

### DIFF
--- a/SCLdialogue.rpy
+++ b/SCLdialogue.rpy
@@ -6941,7 +6941,7 @@ label mcl_somethingtosayremix:
                 "End Login Procedure":
                     return
                 "Retry?":
-                    jump back
+                    jump lockfour
 
     label unlockedfour:
         "PLAYING BACK LOGGED CONVERSATION #403"


### PR DESCRIPTION
Hi,
A game crashed when I clicked the "Retry?" button in a topic that has asked me for a passcode?. After checking the source code I think I have found the issue.

Please review the change, I am unsure how this thing works. I have looked at other instances of the topics that have the passcode thingy to see how it is handled there.

Here is the traceback of the exception: [traceback.txt](https://github.com/user-attachments/files/22583983/traceback.txt)